### PR TITLE
Update Docker options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,8 @@ RUN pip3 install -r /app/requirements.txt
 # and then copy everything else
 COPY ./script /app
 
+# note the port being exposed; this is currently hardcoded in the web service
+EXPOSE 3513
+
 ENTRYPOINT ["python3"]
 CMD ["etl_dropin_ws.py"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each source will have its own dropin command format and its own command parser t
 
 ## Using the service
 
-Note that this service is currently configured to send results to another web service instead of a true data warehouse and will post its results to a path starting with the `DEFAULT_SINK` constant. Example data sink coming soon.
+Note that this service is currently configured to send results to another web service instead of a true data warehouse and will post its results to a path starting with the `DEFAULT_SINK` constant. See associated [example data sink](https://github.com/aedifice/etl-sink).
 
 **Running the service**
 

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,1 +1,1 @@
-docker run -it --rm -p 3513:3513 etl_dropins
+docker run -it --rm -p 3513:3513 -v $(pwd)/script/dropins:/app/dropins:ro --name etl_dropins etl_dropins

--- a/script/etl_endpoints.py
+++ b/script/etl_endpoints.py
@@ -7,7 +7,7 @@ from dropin_parser import parse_dropin
 from sources.web_parser import query_web
 
 DROPIN_DIR = "dropins/"
-DEFAULT_SINK = "http://172.17.0.1:3514/etl/"    # this is where we want to send our data
+DEFAULT_SINK = "http://host.docker.internal:3514/etl/"    # this is where we want to send our data
 
 def dropin_list():
     dropins = []


### PR DESCRIPTION
Refines service's Docker setup. Updates include:
* Since the ETL sink maps its open port to localhost, the default sink location now uses `host.docker.internal` to reach localhost rather than trying to hardcode the sink container's IP.
* Dropins now use a bind mount for dynamic dropins: the service no longer needs to be rebuilt/rerun to pick up new dropins. The directory is read-only since the service is not expected to write or modify dropins.
* Dockerfile now notes which port is exposed for the service to make it easy to find.